### PR TITLE
Add Responsive Mobile-First Projects Page

### DIFF
--- a/src/lib/components/atoms/HeroWrapper.svelte
+++ b/src/lib/components/atoms/HeroWrapper.svelte
@@ -13,7 +13,7 @@
 		position: relative;
 		background-image:
 			radial-gradient(circle, rgba(250, 250, 250, 0.72), rgba(250, 250, 250, 1)),
-			url('images/nautilus-pages-bg.png');
+			url('/images/nautilus-pages-bg.png');
 		background-size: cover;
 		background-repeat: no-repeat;
 		background-position: center;

--- a/src/lib/components/atoms/ProjectCard.svelte
+++ b/src/lib/components/atoms/ProjectCard.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	let { title, timeFrame, content } = $props();
+</script>
+
+<div class="card">
+	<h2>{title}</h2>
+	<h6>{timeFrame}</h6>
+	<p>{content}</p>
+</div>
+
+<style lang="scss">
+	@use '$lib/scss/breakpoints.scss' as bp;
+
+	.card {
+		background-color: rgba(245, 245, 245, 1);
+		border: 1px solid rgba(212, 212, 212, 1);
+		padding: 1.5rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+
+		h6 {
+			color: rgba(163, 163, 163, 1);
+		}
+
+		p {
+			line-height: 1.5;
+		}
+
+		@include bp.for-tablet-portrait-up {
+		}
+
+		@include bp.for-desktop-up {
+			width: 648px;
+			padding: 3rem;
+		}
+	}
+</style>

--- a/src/lib/components/atoms/ProjectPreview.svelte
+++ b/src/lib/components/atoms/ProjectPreview.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	let { title, url } = $props();
+</script>
+
+<div class="wrapper">
+	<div>
+		<img
+			src="https://s3-alpha-sig.figma.com/img/eae3/13a4/8883a46e7a2a60ee806e73a8052191be?Expires=1740355200&Key-Pair-Id=APKAQ4GOSFWCW27IBOMQ&Signature=r6PYYEAZ4niV455l7hw~cwXKPJ9wLHjiL7nC~Vsa5bFvoDwXcXjpuEyA3M5MypiSjSjvJD6XvD6U9rMtYjX5j26il1CferbiOiXtjjcVu8HvRNEwBZJaXBI2b7wEFlO9uPn7L7H1DAsl~K6XBEGVzZDB6t-PPait1DJg~jjEn6X4ptkUsoPgPUnJSJf02c3SiEklOUF-L9BlC4g69vk9LU5MOmBpmnWpGjTIQL0gDi6O~1ngD6eoDsn~~NHIRcUudk1ljFoga7UoipXRAdCY2etfdgA7R8gAxXUyjgV~omQqPwf-QaJitec~qDeriUdeyRyRtwvCnB6w1yKUBbZ07w__"
+			alt=""
+		/>
+	</div>
+	<div class="text">
+		<h3>{title}</h3>
+		<h4>{url}</h4>
+	</div>
+</div>
+
+<style lang="scss">
+	@use '$lib/scss/breakpoints.scss' as bp;
+
+	.wrapper {
+		display: flex;
+		flex-direction: column;
+		background-color: rgba(245, 245, 245, 1);
+		border: 1px solid rgba(212, 212, 212, 1);
+
+		@include bp.for-desktop-up {
+			flex-direction: row;
+		}
+	}
+
+	img {
+		object-fit: cover;
+		height: 176px;
+		width: 100%;
+	}
+
+	.text {
+		padding: 1.5rem;
+
+		@include bp.for-desktop-up {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+		}
+	}
+</style>

--- a/src/lib/components/molecules/FeaturedProject.svelte
+++ b/src/lib/components/molecules/FeaturedProject.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+	import DownArrow from '$lib/icons/downArrow.svelte';
+	import UpArrow from '$lib/icons/upArrow.svelte';
+
+	let isOpen = true;
+</script>
+
+<div class="wrapper">
+	<div class="header">
+		<h3>Project title</h3>
+		<button on:click={() => (isOpen = !isOpen)}>
+			{#if isOpen}
+				<DownArrow />
+			{:else}
+				<UpArrow />
+			{/if}
+		</button>
+	</div>
+	<div class="text-content {isOpen ? 'open' : 'closed'}">
+		<ul>
+			<li>
+				Create a basic simple AI-Assistant for end-users to run on their own local computer that can
+				be expanded and customized.
+			</li>
+			<li>
+				Put in place the necessary infrastructure platform to train and verify new AI modules to be
+				developed by the community.
+			</li>
+			<li>Develop a marketplace platform for additional modules.</li>
+			<li>Share the knowledge and establish a community around our technology</li>
+		</ul>
+		<div class="project-details">
+			<p><strong>Project type:</strong> Vision</p>
+			<p><strong>Stage:</strong> Proof of concept</p>
+			<p><strong>Collaborator:</strong> Company name</p>
+		</div>
+	</div>
+</div>
+
+<style>
+	.wrapper {
+		margin-top: 3rem;
+		border: 1px solid rgba(212, 212, 212, 1);
+	}
+
+	.header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		background-color: rgba(238, 134, 97, 1);
+		padding: 1.5rem 3rem;
+
+		h3 {
+			color: rgba(250, 250, 250, 1);
+		}
+
+		button {
+			cursor: pointer;
+		}
+	}
+
+	.text-content {
+		background-color: rgba(245, 245, 245, 1);
+		padding: 0 3rem;
+		max-height: 0;
+		overflow: hidden;
+		opacity: 0;
+		transition:
+			max-height 0.5s ease-in-out,
+			opacity 0.5s ease-in-out,
+			padding 0.5s ease-in-out;
+	}
+
+	.text-content.open {
+		max-height: 500px;
+		opacity: 1;
+		padding: 3rem;
+	}
+
+	.text-content.closed {
+		max-height: 0;
+		opacity: 0;
+		padding: 0 3rem;
+	}
+
+	.project-details {
+		margin-top: 1.5rem;
+	}
+
+	ul {
+		margin-left: 0;
+	}
+
+	ul li {
+		color: rgba(82, 82, 82, 1);
+		word-break: keep-all;
+		position: relative;
+		padding-left: 1.5rem;
+		text-indent: -1.5rem;
+	}
+</style>

--- a/src/lib/components/organisms/Hero.svelte
+++ b/src/lib/components/organisms/Hero.svelte
@@ -20,7 +20,7 @@
 		position: relative;
 		background-image:
 			radial-gradient(circle, rgba(250, 250, 250, 0.72), rgba(250, 250, 250, 1)),
-			url('images/nautilus-hero-bg.png');
+			url('/images/nautilus-hero-bg.png');
 		background-size: cover;
 		background-repeat: no-repeat;
 		background-position: center;

--- a/src/lib/icons/downArrow.svelte
+++ b/src/lib/icons/downArrow.svelte
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path
+		d="M19.5 8.25L12 15.75L4.5 8.25"
+		stroke="#FAFAFA"
+		stroke-width="1.5"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+</svg>

--- a/src/lib/icons/upArrow.svelte
+++ b/src/lib/icons/upArrow.svelte
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path
+		d="M4.5 15.75L12 8.25L19.5 15.75"
+		stroke="#FAFAFA"
+		stroke-width="1.5"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	/>
+</svg>

--- a/src/lib/scss/global.scss
+++ b/src/lib/scss/global.scss
@@ -30,7 +30,7 @@ body {
 a {
 	color: rgba(238, 134, 97, 1);
 	word-wrap: break-word;
-	word-break: break-all;
+	word-break: keep-all;
 	overflow-wrap: break-word;
 	white-space: normal;
 }

--- a/src/routes/(pages)/projects/+page.svelte
+++ b/src/routes/(pages)/projects/+page.svelte
@@ -1,1 +1,174 @@
-<h1>Projects</h1>
+<script lang="ts">
+	import HeroWrapper from '$lib/components/atoms/HeroWrapper.svelte';
+	import Wrapper from '$lib/components/atoms/Wrapper.svelte';
+	import ProjectCard from '$lib/components/atoms/ProjectCard.svelte';
+	import FeaturedProject from '$lib/components/molecules/FeaturedProject.svelte';
+	import ProjectPreview from '$lib/components/atoms/ProjectPreview.svelte';
+</script>
+
+<Wrapper>
+	<HeroWrapper title={'Projects'} />
+	<div class="projects-wrapper">
+		<div class="hero-text">
+			<p>
+				We work on both external and internal projects. External from customers and internal to
+				realize our own ideas. On this page you will only find a reference to our internal public
+				projects.
+			</p>
+			<p class="para-margin">We have three types of internal projects:</p>
+		</div>
+		<div class="project-cards">
+			<ProjectCard
+				title={'Vision'}
+				timeFrame={'Long term (2-5 years)'}
+				content={'Realize a product and/or service vision geared towards the community to cater to specific need, or interest.'}
+			/>
+			<ProjectCard
+				title={'Stepping stone'}
+				timeFrame={'Short term (3-9 months)'}
+				content={'Create and test the necessary components for our long term projects.'}
+			/>
+			<ProjectCard
+				title={'Spin-off'}
+				timeFrame={'Short term (3-6 months)'}
+				content={'Adapt projects where we see potential of immediate value creation for a more general use by the community.'}
+			/>
+		</div>
+		<div class="project-info">
+			<p>
+				One of our lead values is to create immediate value with everything that we do, which is why
+				Open-Source code is our approach. The code is available to anyone through public
+				repositories on GitHub and we often enter into collaborations with other companies.
+			</p>
+			<p class="para-margin">
+				If you are curious about our roadmap for the coming years and the individual Short-Term
+				projects you can find it <a
+					href="https://github.com/Nautilus-Cyberneering/ai_assistant_roadmap">here</a
+				>.
+			</p>
+		</div>
+		<div class="featured-project">
+			<FeaturedProject />
+		</div>
+		<div class="project-preview-wrapper">
+			<p>
+				For a complete overview of all our repositories please feel free to browse <a
+					href="https://github.com/Nautilus-Cyberneering"
+					>our organization’s repositories on GitHub</a
+				> or check our current most active projects below.
+			</p>
+			<div class="project-preview">
+				<ProjectPreview title={'Page title'} url={'url'} />
+				<ProjectPreview title={'Page title'} url={'url'} />
+				<ProjectPreview title={'Page title'} url={'url'} />
+			</div>
+		</div>
+	</div>
+</Wrapper>
+
+<style lang="scss">
+	@use '$lib/scss/breakpoints.scss' as bp;
+
+	.projects-wrapper {
+		margin-top: 1.5rem;
+		margin-inline: 1.5rem;
+	}
+
+	.para-margin {
+		margin-top: 1.5rem;
+	}
+
+	.project-cards {
+		display: flex;
+		flex-direction: column;
+		gap: 1.5rem;
+		margin-top: 1.5rem;
+	}
+
+	.project-info {
+		margin-top: 3rem;
+	}
+
+	.project-preview-wrapper {
+		margin-top: 3rem;
+
+		.project-preview {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			gap: 1.5rem;
+			margin-top: 3rem;
+		}
+
+		@include bp.for-tablet-portrait-up {
+			.project-preview {
+				display: grid;
+				grid-template-columns: repeat(4, 1fr);
+				grid-template-rows: repeat(2, 1fr);
+				grid-column-gap: 1.5rem;
+				grid-row-gap: 1.5rem;
+
+				:global(> :nth-child(1)) {
+					grid-area: 1 / 1 / 2 / 3;
+				}
+				:global(> :nth-child(2)) {
+					grid-area: 1 / 3 / 2 / 5;
+				}
+				:global(> :nth-child(3)) {
+					grid-area: 2 / 2 / 3 / 4;
+				}
+			}
+		}
+
+		@include bp.for-desktop-up {
+			.project-preview {
+				display: flex;
+				flex-direction: column;
+				gap: 1.5rem;
+				max-width: 776px;
+				margin: 0 auto;
+				padding-block: 3rem 6rem;
+			}
+		}
+	}
+
+	@include bp.for-tablet-portrait-up {
+		.project-cards {
+			display: grid;
+			grid-template-columns: repeat(4, 1fr);
+			grid-template-rows: repeat(2, 1fr);
+			grid-column-gap: 1.5rem;
+			grid-row-gap: 1.5rem;
+
+			:global(> :nth-child(1)) {
+				grid-area: 1 / 1 / 2 / 3;
+			}
+			:global(> :nth-child(2)) {
+				grid-area: 1 / 3 / 2 / 5;
+			}
+			:global(> :nth-child(3)) {
+				grid-area: 2 / 2 / 3 / 4;
+			}
+		}
+	}
+
+	@include bp.for-desktop-up {
+		.hero-text,
+		.project-info,
+		.featured-project,
+		.project-preview-wrapper p {
+			max-width: 776px;
+			margin: 0 auto;
+		}
+
+		.featured-project {
+			max-width: 872px;
+		}
+
+		.project-cards {
+			display: flex;
+			flex-direction: row;
+			margin-block: 3rem;
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary
This PR introduces a mobile-first, responsive design for the Projects page, ensuring better usability across different screen sizes as laid out here https://github.com/nautilus-cyberneering/nautilus-website/issues/3.

* Implemented flexible layouts and responsive styles.
* Improved accessibility and semantic HTML structure.
* Fixed minor UI inconsistencies on smaller screens.
* Created new reusable components for project cards and layout elements.