### PR TITLE
make categories route

### DIFF
--- a/src/lib/components/atoms/Project.svelte
+++ b/src/lib/components/atoms/Project.svelte
@@ -13,21 +13,29 @@
 			<p>
 				{para}
 			</p>
-			<p class="details">
-				<span>Project Type:</span><span> {projectType}</span>
+			<hr />
+			<p class="details details-top">
+				<span class="chip">Project Type:</span><span class="info"> {projectType}</span>
 			</p>
 			<p class="details">
-				<span>Open Source:</span><span> {openSource}</span>
+				<span class="chip">Open Source:</span><span class="info"> {openSource}</span>
 			</p>
 		</div>
 	</div>
 </div>
 
 <style lang="scss">
+	.projects h4 {
+		color: var(--color--text);
+		text-align: center;
+		margin: 1rem;
+	}
+
 	.project {
 		display: flex;
 		justify-content: space-between;
 		margin-top: 1rem;
+		gap: 2rem;
 
 		.image img {
 			margin: 0 auto;
@@ -40,10 +48,31 @@
 		}
 
 		.details {
-			margin-top: 0;
+			margin-top: 0rem;
 			text-align: left;
 			color: var(--color--text);
 			margin-bottom: 0rem;
+
+			.chip,
+			.info {
+				padding: 2px 4px;
+				color: var(--color--text-reverse);
+				font-size: 16px;
+			}
+
+			.chip {
+				border-radius: 4px 0 0 4px;
+				background-color: gray;
+			}
+
+			.info {
+				border-radius: 0 4px 4px 0;
+				background-color: purple;
+			}
+		}
+
+		.details-top {
+			margin-top: 1rem;
 		}
 	}
 

--- a/src/lib/components/atoms/Tag.svelte
+++ b/src/lib/components/atoms/Tag.svelte
@@ -1,10 +1,15 @@
 <script lang="ts">
-	let { tag } = $props();
+	let { tag, category } = $props<{ tag?: string; category?: string }>();
+
+	let value = tag || category;
+	let type = tag ? 'tags' : category ? 'categories' : null;
 </script>
 
-<a href="/tags/{tag}">
-	{tag}
-</a>
+{#if value && type}
+	<a href="/{type}/{value}">
+		{value}
+	</a>
+{/if}
 
 <style>
 	a {

--- a/src/lib/components/atoms/WelcomeCard.svelte
+++ b/src/lib/components/atoms/WelcomeCard.svelte
@@ -14,7 +14,11 @@
 		</ul>
 	</div>
 	<div class="cta-wrapper">
-		<h4>{card.cta}</h4>
+		<h4>
+			<a href="mailto:info@nautilus.cybernering.de">
+				{card.cta}
+			</a>
+		</h4>
 	</div>
 </div>
 
@@ -59,7 +63,7 @@
 			padding: 1.5rem 3rem;
 		}
 
-		h4 {
+		h4 a {
 			color: var(--color--text-reverse);
 			font-size: 28px;
 			text-indent: -1.5rem;

--- a/src/lib/components/molecules/Post.svelte
+++ b/src/lib/components/molecules/Post.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import Tag from '../atoms/Tag.svelte';
+	import Tag from '$lib/components/atoms/Tag.svelte';
 	let {
 		title,
 		date,
@@ -54,7 +54,9 @@
 				{#if categories.length}
 					<div class="categories">
 						<p>Categories:</p>
-						<span>{categories.join(', ')}</span>
+						{#each categories as category}
+							<Tag {category} />
+						{/each}
 					</div>
 				{/if}
 			</div>
@@ -102,26 +104,15 @@
 		.labels {
 			display: flex;
 			flex-direction: column;
-		}
-
-		.categories span {
-			margin-left: 8px;
-		}
-
-		.tags {
-			display: flex;
-			flex-direction: row;
-			align-items: flex-end;
 			gap: 10px;
-
-			p {
-				color: var(--color--text);
-			}
 		}
 
+		.tags,
 		.categories {
 			display: flex;
 			flex-direction: row;
+			align-items: center;
+			gap: 10px;
 
 			p {
 				color: var(--color--text);

--- a/src/routes/api/+server.ts
+++ b/src/routes/api/+server.ts
@@ -1,14 +1,12 @@
-import { getMetadata } from '$lib/data/metadata'; // Import your getMetadata function
+import { getMetadata } from '$lib/data/metadata';
 import { json } from '@sveltejs/kit';
 
 export const GET = async () => {
 	try {
-		// Get metadata using your function
 		const allPosts = getMetadata();
 
-		// Sort posts by date (assuming your metadata has a date field)
 		const sortedPosts = allPosts.sort((a, b) => {
-			const dateA = new Date(a.date); // Adjust this based on your metadata structure
+			const dateA = new Date(a.date);
 			const dateB = new Date(b.date);
 
 			if (isNaN(dateA.getTime()) || isNaN(dateB.getTime())) {
@@ -19,15 +17,12 @@ export const GET = async () => {
 			return dateB.getTime() - dateA.getTime();
 		});
 
-		// If no posts found, return a 404
 		if (!sortedPosts.length) {
 			return { status: 404 };
 		}
 
-		// Return sorted posts as JSON
 		return json(sortedPosts);
 	} catch (err) {
-		// Handle any errors that occur when fetching metadata
 		console.error('Error fetching metadata:', err);
 		return { status: 500, body: { error: 'Internal server error' } };
 	}

--- a/src/routes/blog/useful-new-secure-git-guide/+page.svelte
+++ b/src/routes/blog/useful-new-secure-git-guide/+page.svelte
@@ -94,5 +94,13 @@
 
 	.projects {
 		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		background-color: var(--color--page-secondary);
+		padding: 1rem;
+
+		@include bp.for-tablet-portrait-up {
+			flex-direction: row;
+		}
 	}
 </style>

--- a/src/routes/categories/+layout.svelte
+++ b/src/routes/categories/+layout.svelte
@@ -1,0 +1,11 @@
+<script>
+	/**
+	 * @typedef {Object} Props
+	 * @property {import('svelte').Snippet} [children]
+	 */
+
+	/** @type {Props} */
+	let { children } = $props();
+</script>
+
+{@render children?.()}

--- a/src/routes/categories/+layout.ts
+++ b/src/routes/categories/+layout.ts
@@ -1,0 +1,8 @@
+export const load = async ({ fetch }) => {
+	const response = await fetch(`/api`);
+	const posts = await response.json();
+
+	return {
+		posts
+	};
+};

--- a/src/routes/categories/[categoryId]/+layout.ts
+++ b/src/routes/categories/[categoryId]/+layout.ts
@@ -1,0 +1,10 @@
+export const load = async ({ fetch, params }) => {
+	const response = await fetch(`/api`);
+	const { categoryId } = params;
+	const posts = await response.json();
+
+	return {
+		posts,
+		categoryId
+	};
+};

--- a/src/routes/categories/[categoryId]/+page.svelte
+++ b/src/routes/categories/[categoryId]/+page.svelte
@@ -5,24 +5,24 @@
 	import HeroWrapper from '$lib/components/atoms/HeroWrapper.svelte';
 	import Wrapper from '$lib/components/atoms/Wrapper.svelte';
 
-	const tagId = page.params.tagId;
+	const categoryId = page.params.categoryId;
 	const blogPosts: BlogPost[] = page.data.posts;
 
-	$: postsWithTag = blogPosts.filter((post) => post?.tags?.includes(tagId));
+	$: postsWithCategories = blogPosts.filter((post) => post?.tags?.includes(categoryId));
 </script>
 
 <Wrapper>
 	{#if blogPosts && blogPosts.length}
-		<HeroWrapper title={tagId} />
+		<HeroWrapper title={categoryId} />
 		<div class="container">
 			<p class="tag-count">
-				We found <strong>{postsWithTag.length}</strong>
-				{postsWithTag.length > 1 || postsWithTag.length === 0 ? 'posts' : 'post'} with the tag
-				<strong>{tagId}</strong>
+				We found <strong>{postsWithCategories.length}</strong>
+				{postsWithCategories.length > 1 ? 'posts' : 'post'} with the category
+				<strong>{categoryId}</strong>
 			</p>
 			{#each blogPosts as post}
 				{#if post?.tags}
-					{#if post.tags && post.tags.includes(tagId)}
+					{#if post.tags && post.tags.includes(categoryId)}
 						<TagCard
 							title={post?.title || 'Default title'}
 							coverImage={post?.coverImage || '/images/posts-cover-images/NautilusDefault.png'}

--- a/static/blogMetadata.json
+++ b/static/blogMetadata.json
@@ -1,5 +1,21 @@
 [
   {
+    "title": "A challenging journey – The origins of Boken",
+    "slug": "a-challenging-journey-the-origins-of-boken",
+    "contributor": "Fernando Torres",
+    "contributorSlug": "fernando-torres",
+    "date": "2021-06-28T00:00:00.000Z",
+    "coverImage": "/images/posts-cover-images/a-challenging-journey.jpg",
+    "excerpt": "Throughout 2020 we had to face a lot of challenges, so at the beginning of 2021 we were more than ready to face a new one, which resulted in Boken Engine. This time in the form of a new project, something none of us had ever been asked to do before.",
+    "tags": [
+      "Boken Engine",
+      "Iakkai Saga"
+    ],
+    "categories": [
+      "Open Source"
+    ]
+  },
+  {
     "title": "A Personal Retrospective: Feedback and Thoughts",
     "slug": "a-personal-retrospective-feedback-and-thoughts",
     "contributor": "Yeray Rodriguez",
@@ -16,19 +32,19 @@
     ]
   },
   {
-    "title": "Contributing to an Open Source Project as a Non Developer",
-    "slug": "contributing-to-an-open-source-project-as-a-non-developer",
+    "title": "Brand New Rusty Torrents?",
+    "slug": "brand-new-rusty-torrents",
     "contributor": "Constantin Bosse",
     "contributorSlug": "constantin-bosse",
-    "date": "2021-08-18T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/contributing-to-open-source.jpg",
-    "excerpt": "In this post you will learn about my experience as a non-developer helping to take a closed source software project, a non-linear visual story framework for IOS Swift, into the Open Source realm and develop a demo for it.",
+    "date": "2022-07-21T00:00:00.000Z",
+    "coverImage": "/images/posts-cover-images/torrust-header.jpg",
+    "excerpt": "What has Rusty to do with Brand New? If you’re a geek, chances are you’ve heard of torrents. If you haven’t, torrents are a file sharing technology. Torrents allow users to share large files quickly and easily in a decentralized manner.",
     "tags": [
-      "Boken Engine",
-      "Iakkai Saga"
+      "Torrust"
     ],
     "categories": [
-      "Open Source"
+      "Open Source",
+      "Products"
     ]
   },
   {
@@ -49,38 +65,6 @@
     ]
   },
   {
-    "title": "A challenging journey – The origins of Boken",
-    "slug": "a-challenging-journey-the-origins-of-boken",
-    "contributor": "Fernando Torres",
-    "contributorSlug": "fernando-torres",
-    "date": "2021-06-28T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/a-challenging-journey.jpg",
-    "excerpt": "Throughout 2020 we had to face a lot of challenges, so at the beginning of 2021 we were more than ready to face a new one, which resulted in Boken Engine. This time in the form of a new project, something none of us had ever been asked to do before.",
-    "tags": [
-      "Boken Engine",
-      "Iakkai Saga"
-    ],
-    "categories": [
-      "Open Source"
-    ]
-  },
-  {
-    "title": "Brand New Rusty Torrents?",
-    "slug": "brand-new-rusty-torrents",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-07-21T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/torrust-header.jpg",
-    "excerpt": "What has Rusty to do with Brand New? If you’re a geek, chances are you’ve heard of torrents. If you haven’t, torrents are a file sharing technology. Torrents allow users to share large files quickly and easily in a decentralized manner.",
-    "tags": [
-      "Torrust"
-    ],
-    "categories": [
-      "Open Source",
-      "Products"
-    ]
-  },
-  {
     "title": "Extraordinary First Company Reunion in Gran Canaria for 2022",
     "slug": "extraordinary-first-company-reunion-in-gran-canaria-for-2022",
     "contributor": "Constantin Bosse",
@@ -93,6 +77,22 @@
     ],
     "categories": [
       "Team"
+    ]
+  },
+  {
+    "title": "Contributing to an Open Source Project as a Non Developer",
+    "slug": "contributing-to-an-open-source-project-as-a-non-developer",
+    "contributor": "Constantin Bosse",
+    "contributorSlug": "constantin-bosse",
+    "date": "2021-08-18T00:00:00.000Z",
+    "coverImage": "/images/posts-cover-images/contributing-to-open-source.jpg",
+    "excerpt": "In this post you will learn about my experience as a non-developer helping to take a closed source software project, a non-linear visual story framework for IOS Swift, into the Open Source realm and develop a demo for it.",
+    "tags": [
+      "Boken Engine",
+      "Iakkai Saga"
+    ],
+    "categories": [
+      "Open Source"
     ]
   },
   {


### PR DESCRIPTION
* Set up `/categories` route so that the categories at the bottom of each blog post links to a page which displays each blog post that contains that category, as is currently the case in `/tags`
* Add email link in `WelcomeCard.svelte` so that when the user clicks on `Contribute` or `Create`, an email window to contact `info@nautilus.cybernering.de` opens, as is the case on the current site https://nautilus-cyberneering.de/
* Finished styling repo displays in the blog post `Useful New Secure Git Guide`