### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js (if using a Node-based static site generator)
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Build site
+        run: |
+          npm install
+          npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build
+          cname: nautilus-cyberneering.dev

--- a/static/blogMetadata.json
+++ b/static/blogMetadata.json
@@ -1,347 +1,233 @@
 [
-  {
-    "title": "A challenging journey – The origins of Boken",
-    "slug": "a-challenging-journey-the-origins-of-boken",
-    "contributor": "Fernando Torres",
-    "contributorSlug": "fernando-torres",
-    "date": "2021-06-28T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/a-challenging-journey.jpg",
-    "excerpt": "Throughout 2020 we had to face a lot of challenges, so at the beginning of 2021 we were more than ready to face a new one, which resulted in Boken Engine. This time in the form of a new project, something none of us had ever been asked to do before.",
-    "tags": [
-      "Boken Engine",
-      "Iakkai Saga"
-    ],
-    "categories": [
-      "Open Source"
-    ]
-  },
-  {
-    "title": "A Personal Retrospective: Feedback and Thoughts",
-    "slug": "a-personal-retrospective-feedback-and-thoughts",
-    "contributor": "Yeray Rodriguez",
-    "contributorSlug": "yeray-rodriguez",
-    "date": "2022-06-30T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/a-personal-retrospective.jpg",
-    "excerpt": "This post is the retrospective and the personal feedback report I wrote to the management of Nautilus Cyberneering on my experience of working with Nautilus Cyberneering's team as an external contributor.",
-    "tags": [
-      "Feedback",
-      "Projects"
-    ],
-    "categories": [
-      "Team"
-    ]
-  },
-  {
-    "title": "AI unexpected behavior – Why transparency in AI is vital",
-    "slug": "ai-unexpected-behavior-why-transparency-in-ai-is-vital",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-05-31T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/ai-unexpected-behaviour.jpg",
-    "excerpt": "Have you ever thought about what happens when there is AI unexpected behavior?",
-    "tags": [
-      "Ethics",
-      "Security",
-      "Transparency"
-    ],
-    "categories": [
-      "AI",
-      "Open Source"
-    ]
-  },
-  {
-    "title": "Brand New Rusty Torrents?",
-    "slug": "brand-new-rusty-torrents",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-07-21T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/torrust-header.jpg",
-    "excerpt": "What has Rusty to do with Brand New? If you’re a geek, chances are you’ve heard of torrents. If you haven’t, torrents are a file sharing technology. Torrents allow users to share large files quickly and easily in a decentralized manner.",
-    "tags": [
-      "Torrust"
-    ],
-    "categories": [
-      "Open Source",
-      "Products"
-    ]
-  },
-  {
-    "title": "Extraordinary First Company Reunion in Gran Canaria for 2022",
-    "slug": "extraordinary-first-company-reunion-in-gran-canaria-for-2022",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-05-02T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/extraordinary-first-company-reunion.jpg",
-    "excerpt": "Beginning of last month we had two intensive weeks of in person meetings and activities with the visit of our CEO and CTO, Cameron Garnham.",
-    "tags": [
-      "Meeting"
-    ],
-    "categories": [
-      "Team"
-    ]
-  },
-  {
-    "title": "What is Fintech.Li 2022?",
-    "slug": "excited-to-attend-fintech-li-2022",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-09-13T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/excited-to-attend-fintech.jpg",
-    "excerpt": "We are excited to announce that we are attending Fintech.Li 2022 conference on the 28 of this month!",
-    "tags": [
-      "Blockchain",
-      "Fintech",
-      "Web3"
-    ],
-    "categories": [
-      "Events"
-    ]
-  },
-  {
-    "title": "Contributing to an Open Source Project as a Non Developer",
-    "slug": "contributing-to-an-open-source-project-as-a-non-developer",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2021-08-18T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/contributing-to-open-source.jpg",
-    "excerpt": "In this post you will learn about my experience as a non-developer helping to take a closed source software project, a non-linear visual story framework for IOS Swift, into the Open Source realm and develop a demo for it.",
-    "tags": [
-      "Boken Engine",
-      "Iakkai Saga"
-    ],
-    "categories": [
-      "Open Source"
-    ]
-  },
-  {
-    "title": "Great jsdaycanarias 2022 Software Developer Event",
-    "slug": "great-jsdaycanarias-2022-software-developer-event",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-05-11T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/jsdaycanarias-2022.jpg",
-    "excerpt": "Last week my colleague Jose Celano and myself attended then jsdaycanarias 2022 software developer event.",
-    "tags": [
-      "Marketing"
-    ],
-    "categories": [
-      "Events"
-    ]
-  },
-  {
-    "title": "How to use GPG Keys the Right Way With GitHub",
-    "slug": "how-to-use-gpg-keys-the-right-way-with-github",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-02-08T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/how-to-use-gpg.jpg",
-    "excerpt": "Assuring the authenticity of work submitted to GitHub has become increasingly important. One of the common policies that organizations have used to secure the commits made by developers has been to require the use of GPG signatures that are embedded into the Git commits.",
-    "tags": [
-      "GitHub",
-      "Security"
-    ],
-    "categories": [
-      "Open Source"
-    ]
-  },
-  {
-    "title": "Iakkai Saga available on the App Store!",
-    "slug": "iakkai-saga-available-on-the-app-store",
-    "contributor": "Jose Celano",
-    "contributorSlug": "jose-celano",
-    "date": "2021-08-13T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/iakkai-saga-available.png",
-    "excerpt": "After some months of hard work we finally published the first application built entirely using Boken Engine, Iakkai Saga: The Curse of Blood.",
-    "tags": [
-      "Boken Engine",
-      "Game",
-      "Iakkai Saga",
-      "iOS"
-    ],
-    "categories": [
-      "Open Source"
-    ]
-  },
-  {
-    "title": "Iakkai Saga Visual Story Game for MacOS",
-    "slug": "iakkai-saga-for-macos",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2021-08-17T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/iakkai-saga-visual-story-game.jpg",
-    "excerpt": "Although you can easily build and run the Iakkai Saga demo project on your macOS, we wanted to have a simpler way to execute it. We wanted to show what you can build using Boken Engine even before knowing how to do it.",
-    "tags": [
-      "Boken Engine",
-      "Iakkai Saga",
-      "iOS"
-    ],
-    "categories": [
-      "Open Source"
-    ]
-  },
-  {
-    "title": "Interesting Article: 4 tips to becoming a technical writer with open source contributions",
-    "slug": "interesting-article-4-tips-to-becoming-a-technical-writer-with-open-source-contributions",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2021-11-05T00:00:00.000Z",
-    "coverImage": "",
-    "excerpt": "This is an excellent article by Ashley Hardin giving some useful tips that essentially states that...",
-    "tags": [
-      "Collaboration",
-      "Reshare"
-    ],
-    "categories": [
-      "Open Source"
-    ]
-  },
-  {
-    "title": "Natural Language Processing AI Technology a Quick and Brief Intro with Examples",
-    "slug": "natural-language-processing-ai",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-02-17T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/nlp-featured-image.jpg",
-    "excerpt": "The company that I currently work for, Nautilus Cyberneering, has a 5 year project for which the so called Natural Language Processing AI is key. We essentially want to create a virtual artificial intelligence assistant that you can run from your own local computer and communicate with you through a command line interface.",
-    "tags": [
-      "NLP"
-    ],
-    "categories": [
-      "Open Source",
-      "AI"
-    ]
-  },
-  {
-    "title": "Open Source Sources of Income Easy Tools and Aids",
-    "slug": "open-source-sources-of-income-easy-tools-and-aids",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-07-15T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/open-source-sources-of-income.jpg",
-    "excerpt": "It’s no secret that Open Source projects have a difficult time being financially sustainable and search for sources of income. Fact is many projects struggle just to keep the lights on.",
-    "tags": [
-      "Income",
-      "Tools"
-    ],
-    "categories": [
-      "Open Source",
-      "tools"
-    ]
-  },
-  {
-    "title": "Open Source – Why it is so important now and in the future",
-    "slug": "open-source-why-it-is-so-important-now-and-in-the-future",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-05-24T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/open-source-why-it-is-so-important.jpg",
-    "excerpt": "The tech world is ever-changing, and constantly evolving and a mix of different business philosophies coexist.",
-    "tags": [
-      "Collaboration",
-      "Future",
-      "Security"
-    ],
-    "categories": [
-      "Open Source",
-      "AI"
-    ]
-  },
-  {
-    "title": "Simple Media Management System Using GitHub Repositories",
-    "slug": "simple-media-management-system-using-github-repositories",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2021-11-12T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/simple-media-management-system.jpg",
-    "excerpt": "Our current new project is to create a simple media management system through GitHub repositories and GitHub actions.",
-    "tags": [
-      "Collaboration",
-      "GitHub"
-    ],
-    "categories": [
-      "Open Source"
-    ]
-  },
-  {
-    "title": "Useful New Secure Git Guide",
-    "slug": "useful-new-secure-git-guide",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-07-27T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/useful-new-secure-git-guide.jpg",
-    "excerpt": "Last month we launched our Secure Git Guide. We decided to create it so that other developers can benefit from our insights from the work that we are doing involving advanced Git.",
-    "tags": [
-      "Git"
-    ],
-    "categories": [
-      "Open Source",
-      "Tools"
-    ]
-  },
-  {
-    "title": "Webinar: AI, Metaverse. What they are and how they can add value to my business",
-    "slug": "webinar-ai-metaverse-what-they-are-and-how-they-can-add-value-to-my-business",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-04-22T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/webinar.jpg",
-    "excerpt": "End of last month we presented at a webinar organized by the German Chamber of Commerce in Spain.",
-    "tags": [
-      "Webinar"
-    ],
-    "categories": [
-      "AI",
-      "Press"
-    ]
-  },
-  {
-    "title": "What is GPG? Why and how to use it?",
-    "slug": "what-is-gpg-why-and-how-to-use-it",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-01-28T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/what-is-gpg.jpg",
-    "excerpt": "I did not have a clue about what is meant by GPG when I heard it. As it turned out to be it has to do with security.",
-    "tags": [
-      "Security"
-    ],
-    "categories": [
-      "Open Source"
-    ]
-  },
-  {
-    "title": "What it is like to be part of the Nautilus Cyberneering team",
-    "slug": "what-it-is-like-to-be-part-of-the-nautilus-cyberneering-team",
-    "contributor": "Constantin Bosse",
-    "contributorSlug": "constantin-bosse",
-    "date": "2022-05-17T00:00:00.000Z",
-    "coverImage": "/images/posts-cover-images/what-it-is-like-to-be-part-of-the-nautilus-team.jpg",
-    "excerpt": "I recently attended a Software Developer event in Tenerife called JSDay for which I had been giving much thought to possible questions by someone considering Nautilus Cyberneering.",
-    "tags": [
-      "Open Source",
-      "Products",
-      "Torrust"
-    ],
-    "categories": [
-      "Open Source",
-      "Products"
-    ]
-  },
-  {
-    "title": "Yeray Thanks! Our pleasure to have had you on our team!",
-    "slug": "yeray-thanks-our-pleasure-to-have-had-you-on-our-team",
-    "contributor": "Cameron Garnham",
-    "contributorSlug": "cameron-garnham",
-    "date": "2022-07-09T00:00:00.000Z",
-    "coverImage": "",
-    "excerpt": "Yeray recently left our team after contributing his unique set of professional skills and abilities towards our projects. He has been kind, reliable, attentive, self-motivated, and methodical in his approach. ",
-    "tags": [
-      "Open Source",
-      "Team"
-    ],
-    "categories": [
-      "Ethics",
-      "Transparency"
-    ]
-  }
+	{
+		"title": "A Personal Retrospective: Feedback and Thoughts",
+		"slug": "a-personal-retrospective-feedback-and-thoughts",
+		"contributor": "Yeray Rodriguez",
+		"contributorSlug": "yeray-rodriguez",
+		"date": "2022-06-30T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/a-personal-retrospective.jpg",
+		"excerpt": "This post is the retrospective and the personal feedback report I wrote to the management of Nautilus Cyberneering on my experience of working with Nautilus Cyberneering's team as an external contributor.",
+		"tags": ["Feedback", "Projects"],
+		"categories": ["Team"]
+	},
+	{
+		"title": "A challenging journey – The origins of Boken",
+		"slug": "a-challenging-journey-the-origins-of-boken",
+		"contributor": "Fernando Torres",
+		"contributorSlug": "fernando-torres",
+		"date": "2021-06-28T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/a-challenging-journey.jpg",
+		"excerpt": "Throughout 2020 we had to face a lot of challenges, so at the beginning of 2021 we were more than ready to face a new one, which resulted in Boken Engine. This time in the form of a new project, something none of us had ever been asked to do before.",
+		"tags": ["Boken Engine", "Iakkai Saga"],
+		"categories": ["Open Source"]
+	},
+	{
+		"title": "Brand New Rusty Torrents?",
+		"slug": "brand-new-rusty-torrents",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-07-21T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/torrust-header.jpg",
+		"excerpt": "What has Rusty to do with Brand New? If you’re a geek, chances are you’ve heard of torrents. If you haven’t, torrents are a file sharing technology. Torrents allow users to share large files quickly and easily in a decentralized manner.",
+		"tags": ["Torrust"],
+		"categories": ["Open Source", "Products"]
+	},
+	{
+		"title": "Contributing to an Open Source Project as a Non Developer",
+		"slug": "contributing-to-an-open-source-project-as-a-non-developer",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2021-08-18T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/contributing-to-open-source.jpg",
+		"excerpt": "In this post you will learn about my experience as a non-developer helping to take a closed source software project, a non-linear visual story framework for IOS Swift, into the Open Source realm and develop a demo for it.",
+		"tags": ["Boken Engine", "Iakkai Saga"],
+		"categories": ["Open Source"]
+	},
+	{
+		"title": "AI unexpected behavior – Why transparency in AI is vital",
+		"slug": "ai-unexpected-behavior-why-transparency-in-ai-is-vital",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-05-31T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/ai-unexpected-behaviour.jpg",
+		"excerpt": "Have you ever thought about what happens when there is AI unexpected behavior?",
+		"tags": ["Ethics", "Security", "Transparency"],
+		"categories": ["AI", "Open Source"]
+	},
+	{
+		"title": "What is Fintech.Li 2022?",
+		"slug": "excited-to-attend-fintech-li-2022",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-09-13T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/excited-to-attend-fintech.jpg",
+		"excerpt": "We are excited to announce that we are attending Fintech.Li 2022 conference on the 28 of this month!",
+		"tags": ["Blockchain", "Fintech", "Web3"],
+		"categories": ["Events"]
+	},
+	{
+		"title": "Extraordinary First Company Reunion in Gran Canaria for 2022",
+		"slug": "extraordinary-first-company-reunion-in-gran-canaria-for-2022",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-05-02T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/extraordinary-first-company-reunion.jpg",
+		"excerpt": "Beginning of last month we had two intensive weeks of in person meetings and activities with the visit of our CEO and CTO, Cameron Garnham.",
+		"tags": ["Meeting"],
+		"categories": ["Team"]
+	},
+	{
+		"title": "Great jsdaycanarias 2022 Software Developer Event",
+		"slug": "great-jsdaycanarias-2022-software-developer-event",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-05-11T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/jsdaycanarias-2022.jpg",
+		"excerpt": "Last week my colleague Jose Celano and myself attended then jsdaycanarias 2022 software developer event.",
+		"tags": ["Marketing"],
+		"categories": ["Events"]
+	},
+	{
+		"title": "How to use GPG Keys the Right Way With GitHub",
+		"slug": "how-to-use-gpg-keys-the-right-way-with-github",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-02-08T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/how-to-use-gpg.jpg",
+		"excerpt": "Assuring the authenticity of work submitted to GitHub has become increasingly important. One of the common policies that organizations have used to secure the commits made by developers has been to require the use of GPG signatures that are embedded into the Git commits.",
+		"tags": ["GitHub", "Security"],
+		"categories": ["Open Source"]
+	},
+	{
+		"title": "Iakkai Saga available on the App Store!",
+		"slug": "iakkai-saga-available-on-the-app-store",
+		"contributor": "Jose Celano",
+		"contributorSlug": "jose-celano",
+		"date": "2021-08-13T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/iakkai-saga-available.png",
+		"excerpt": "After some months of hard work we finally published the first application built entirely using Boken Engine, Iakkai Saga: The Curse of Blood.",
+		"tags": ["Boken Engine", "Game", "Iakkai Saga", "iOS"],
+		"categories": ["Open Source"]
+	},
+	{
+		"title": "Natural Language Processing AI Technology a Quick and Brief Intro with Examples",
+		"slug": "natural-language-processing-ai",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-02-17T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/nlp-featured-image.jpg",
+		"excerpt": "The company that I currently work for, Nautilus Cyberneering, has a 5 year project for which the so called Natural Language Processing AI is key. We essentially want to create a virtual artificial intelligence assistant that you can run from your own local computer and communicate with you through a command line interface.",
+		"tags": ["NLP"],
+		"categories": ["Open Source", "AI"]
+	},
+	{
+		"title": "Interesting Article: 4 tips to becoming a technical writer with open source contributions",
+		"slug": "interesting-article-4-tips-to-becoming-a-technical-writer-with-open-source-contributions",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2021-11-05T00:00:00.000Z",
+		"coverImage": "",
+		"excerpt": "This is an excellent article by Ashley Hardin giving some useful tips that essentially states that...",
+		"tags": ["Collaboration", "Reshare"],
+		"categories": ["Open Source"]
+	},
+	{
+		"title": "Open Source Sources of Income Easy Tools and Aids",
+		"slug": "open-source-sources-of-income-easy-tools-and-aids",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-07-15T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/open-source-sources-of-income.jpg",
+		"excerpt": "It’s no secret that Open Source projects have a difficult time being financially sustainable and search for sources of income. Fact is many projects struggle just to keep the lights on.",
+		"tags": ["Income", "Tools"],
+		"categories": ["Open Source", "tools"]
+	},
+	{
+		"title": "Iakkai Saga Visual Story Game for MacOS",
+		"slug": "iakkai-saga-for-macos",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2021-08-17T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/iakkai-saga-visual-story-game.jpg",
+		"excerpt": "Although you can easily build and run the Iakkai Saga demo project on your macOS, we wanted to have a simpler way to execute it. We wanted to show what you can build using Boken Engine even before knowing how to do it.",
+		"tags": ["Boken Engine", "Iakkai Saga", "iOS"],
+		"categories": ["Open Source"]
+	},
+	{
+		"title": "Open Source – Why it is so important now and in the future",
+		"slug": "open-source-why-it-is-so-important-now-and-in-the-future",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-05-24T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/open-source-why-it-is-so-important.jpg",
+		"excerpt": "The tech world is ever-changing, and constantly evolving and a mix of different business philosophies coexist.",
+		"tags": ["Collaboration", "Future", "Security"],
+		"categories": ["Open Source", "AI"]
+	},
+	{
+		"title": "Useful New Secure Git Guide",
+		"slug": "useful-new-secure-git-guide",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-07-27T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/useful-new-secure-git-guide.jpg",
+		"excerpt": "Last month we launched our Secure Git Guide. We decided to create it so that other developers can benefit from our insights from the work that we are doing involving advanced Git.",
+		"tags": ["Git"],
+		"categories": ["Open Source", "Tools"]
+	},
+	{
+		"title": "Simple Media Management System Using GitHub Repositories",
+		"slug": "simple-media-management-system-using-github-repositories",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2021-11-12T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/simple-media-management-system.jpg",
+		"excerpt": "Our current new project is to create a simple media management system through GitHub repositories and GitHub actions.",
+		"tags": ["Collaboration", "GitHub"],
+		"categories": ["Open Source"]
+	},
+	{
+		"title": "Webinar: AI, Metaverse. What they are and how they can add value to my business",
+		"slug": "webinar-ai-metaverse-what-they-are-and-how-they-can-add-value-to-my-business",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-04-22T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/webinar.jpg",
+		"excerpt": "End of last month we presented at a webinar organized by the German Chamber of Commerce in Spain.",
+		"tags": ["Webinar"],
+		"categories": ["AI", "Press"]
+	},
+	{
+		"title": "What is GPG? Why and how to use it?",
+		"slug": "what-is-gpg-why-and-how-to-use-it",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-01-28T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/what-is-gpg.jpg",
+		"excerpt": "I did not have a clue about what is meant by GPG when I heard it. As it turned out to be it has to do with security.",
+		"tags": ["Security"],
+		"categories": ["Open Source"]
+	},
+	{
+		"title": "What it is like to be part of the Nautilus Cyberneering team",
+		"slug": "what-it-is-like-to-be-part-of-the-nautilus-cyberneering-team",
+		"contributor": "Constantin Bosse",
+		"contributorSlug": "constantin-bosse",
+		"date": "2022-05-17T00:00:00.000Z",
+		"coverImage": "/images/posts-cover-images/what-it-is-like-to-be-part-of-the-nautilus-team.jpg",
+		"excerpt": "I recently attended a Software Developer event in Tenerife called JSDay for which I had been giving much thought to possible questions by someone considering Nautilus Cyberneering.",
+		"tags": ["Open Source", "Products", "Torrust"],
+		"categories": ["Open Source", "Products"]
+	},
+	{
+		"title": "Yeray Thanks! Our pleasure to have had you on our team!",
+		"slug": "yeray-thanks-our-pleasure-to-have-had-you-on-our-team",
+		"contributor": "Cameron Garnham",
+		"contributorSlug": "cameron-garnham",
+		"date": "2022-07-09T00:00:00.000Z",
+		"coverImage": "",
+		"excerpt": "Yeray recently left our team after contributing his unique set of professional skills and abilities towards our projects. He has been kind, reliable, attentive, self-motivated, and methodical in his approach. ",
+		"tags": ["Open Source", "Team"],
+		"categories": ["Ethics", "Transparency"]
+	}
 ]


### PR DESCRIPTION
# Add GitHub Actions workflow for deploying to GitHub Pages

## Summary
- Created `.github/workflows/deploy.yml` to automate deployment of the static site.
- Workflow triggers on pushes to the `main` branch.
- Installs Node.js (v18), installs dependencies, runs the build script (`npm run build`), and deploys the generated `build` folder to GitHub Pages using `peaceiris/actions-gh-pages`.
- Publishes from the `build` directory and sets the custom domain `nautilus-cyberneering.dev`.
- Configured permissions for content write access.
- Automates publishing on every update to `main`.

## Additional Context

This change addresses issue [#9](https://github.com/nautilus-cyberneering/nautilus-website/issues/9#issuecomment-2897663058), where the DNS was configured as follows:
```
dig nautilus-cyberneering.dev +noall +answer -t A
nautilus-cyberneering.dev. 1799 IN A 185.199.109.153
nautilus-cyberneering.dev. 1799 IN A 185.199.108.153
nautilus-cyberneering.dev. 1799 IN A 185.199.111.153
nautilus-cyberneering.dev. 1799 IN A 185.199.110.153
dig nautilus-cyberneering.dev +noall +answer -t AAAA
nautilus-cyberneering.dev. 1799 IN AAAA 2606:50c0:8002::153
nautilus-cyberneering.dev. 1799 IN AAAA 2606:50c0:8000::153
nautilus-cyberneering.dev. 1799 IN AAAA 2606:50c0:8001::153
nautilus-cyberneering.dev. 1799 IN AAAA 2606:50c0:8003::153
```


Reference:  
[GitHub Docs - Configuring an apex domain for GitHub Pages](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain)

According to the linked discussion, the workflow eliminates the need for a manual `CNAME` file because the `peaceiris/actions-gh-pages` action handles it automatically. This was the primary motivation for this update.