### PR TITLE
Fix hardcoded urls in Playwright tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,14 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-	testDir: './tests'
+  testDir: './tests',
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:5173'
+  },
+  webServer: {
+    command: 'npm run dev',
+    url: process.env.BASE_URL || 'http://localhost:5173',
+    timeout: 120_000,
+    reuseExistingServer: true
+  }
 });

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,4 @@
 {
-	"status": "passed",
-	"failedTests": []
+  "status": "passed",
+  "failedTests": []
 }

--- a/tests/header.spec.ts
+++ b/tests/header.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('Header logo is visible and links to home', async ({ page }) => {
-	await page.goto('http://localhost:5173/');
+	await page.goto('/');
 
 	// The logo link should be visible and have the correct aria-label
 	const logo = page.getByRole('link', { name: /site logo/i });
@@ -12,11 +12,11 @@ test('Header logo is visible and links to home', async ({ page }) => {
 
 	// Clicking the logo should navigate to the homepage
 	await logo.click();
-	await expect(page).toHaveURL('http://localhost:5173/');
+	await expect(page).toHaveURL('/');
 });
 
 test('Header navigation links are visible and work', async ({ page }) => {
-	await page.goto('http://localhost:5173/');
+	await page.goto('/');
 
 	// Navigation links
 	const navLinks = [
@@ -30,12 +30,12 @@ test('Header navigation links are visible and work', async ({ page }) => {
 		const link = page.getByRole('link', { name, exact: true });
 		await expect(link).toBeVisible();
 		await link.click();
-		await expect(page).toHaveURL(`http://localhost:5173${path}`);
+		await expect(page).toHaveURL(path);
 	}
 });
 
 test('Header theme toggle is visible and switches theme', async ({ page }) => {
-	await page.goto('http://localhost:5173/');
+	await page.goto('/');
 
 	// Find the theme toggle button (adjust selector if needed)
 	const themeToggle = page.getByRole('button', { name: /theme|toggle/i });
@@ -62,7 +62,7 @@ test('Header theme toggle is visible and switches theme', async ({ page }) => {
 //   // Set viewport to mobile size
 //   await page.setViewportSize({ width: 375, height: 800 });
 
-//   await page.goto('http://localhost:5173/');
+//   await page.goto('/');
 
 //   // Hamburger menu button should be visible
 //   const hamburger = page.getByRole('button', { name: /toggle menu/i });

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('homepage loads and shows key sections', async ({ page }) => {
-	await page.goto('http://localhost:5173/');
+	await page.goto('/');
 
 	await expect(
 		page.getByRole('heading', { name: /pioneering open source ecosystems/i })
@@ -12,7 +12,7 @@ test('homepage loads and shows key sections', async ({ page }) => {
 });
 
 test('homepage shows three latest articles and article links work', async ({ page }) => {
-	await page.goto('http://localhost:5173/');
+	await page.goto('/');
 
 	const articles = page.locator('.article-wrapper .card');
 	await expect(articles).toHaveCount(3);
@@ -26,7 +26,7 @@ test('homepage shows three latest articles and article links work', async ({ pag
 });
 
 test('TechAndProjects HomeCards have working links', async ({ page }) => {
-	await page.goto('http://localhost:5173/');
+	await page.goto('/');
 
 	// Locate the HomeCards in the TechAndProjects section
 	// Adjust selector if needed to be more specific to TechAndProjects
@@ -49,7 +49,7 @@ test('TechAndProjects HomeCards have working links', async ({ page }) => {
 });
 
 test('ExplorationAndEduction RepoCards have working links', async ({ page }) => {
-	await page.goto('http://localhost:5173/');
+	await page.goto('/');
 
 	// Locate the RepoCards in the ExplorationAndEduction section
 	const repoCards = page.locator('.repo-wrapper .card');


### PR DESCRIPTION
### Refactor Playwright Tests to Use Configurable `baseURL` and Auto-Start Dev Server

**Related issue:** [[#55 — Fix hardcoded URLs in Playwright tests](https://github.com/nautilus-cyberneering/nautilus-website/issues/55)

---

#### **Problem**

Playwright E2E tests previously used **hardcoded URLs** (`http://localhost:5173/`), which caused:

* Failures when the dev server ran on a different port
* Inability to test against staging or production environments
* Tests failing when the dev server was not already running
* Duplicate URLs scattered across test files

---

#### **Solution**

**Centralized configuration:**
Added a `baseURL` in `playwright.config.ts`:

```ts
use: {
  baseURL: process.env.BASE_URL || 'http://localhost:5173'
}
```

**Auto-start dev server for tests:**
Added a `webServer` block so Playwright automatically starts the dev server if it’s not running:

```ts
webServer: {
  command: 'npm run dev',
  url: process.env.BASE_URL || 'http://localhost:5173',
  timeout: 120_000,
  reuseExistingServer: true
}
```

**Removed hardcoded URLs:**
Replaced absolute URLs (`http://localhost:5173/`) with relative paths (`'/'`) in:

* `tests/header.spec.ts`
* `tests/home.spec.ts`

**Added environment variable support:**
Developers can now override the default URL:

```bash
BASE_URL=https://staging.example.com npx playwright test
```

---

#### **Acceptance Criteria**

* All hardcoded URLs removed from test files
* Tests use relative paths and the configured `baseURL`
* Dev server starts automatically if not already running
* Tests can run against any environment using `BASE_URL`
* No manual setup required before running E2E tests

---

**Outcome:**
E2E testing is now **portable**, **configurable**, and **self-sufficient** — no more failed runs due to missing servers or mismatched ports.